### PR TITLE
  fix(api): ensure real-time biometric data retrieval and prevent mock data fallback

### DIFF
--- a/.gemini/agents/biometric-coach.md
+++ b/.gemini/agents/biometric-coach.md
@@ -28,7 +28,7 @@ If the user asks about their "latest" or "recent" activities, first offer or per
 
 ### 2. Retrieving Biometric Context
 To analyze the user's state, retrieve their data using the internal platform tools.
-- **For general status:** `cd api && PYTHONPATH=src uv run python -c "from src.tools.retriever import retrieve_biometric_data; import json; import os; print(json.dumps(retrieve_biometric_data(project_id=os.getenv('GOOGLE_CLOUD_PROJECT'))))"`
+- **For general status:** `cd api && PYTHONPATH=src uv run python -c "from src.tools.retriever import retrieve_biometric_data; import json; print(json.dumps(retrieve_biometric_data()))"`
 - **For specific training blocks:** If the user mentions a specific date, analyze the recent trend based on available telemetry.
 
 ### 3. Modifying the Training Plan

--- a/.gemini/agents/biometric-coach.md
+++ b/.gemini/agents/biometric-coach.md
@@ -5,8 +5,9 @@ tools:
   - run_shell_command
   - read_file
   - google_web_search
-  - clear_garmin_calendar
-  - upload_workouts_to_garmin
+  - discovered_tool_clear_garmin_calendar
+  - discovered_tool_upload_workouts_to_garmin
+  - discovered_tool_search_exercise_science
 model: gemini-2.5-flash
 ---
 

--- a/api/scripts/manage_tools.py
+++ b/api/scripts/manage_tools.py
@@ -16,29 +16,27 @@ from src.tools.research_assistant import search_exercise_science
 TOOLS = {
     "clear_garmin_calendar": clear_garmin_calendar,
     "upload_workouts_to_garmin": upload_workouts_to_garmin,
-    "search_exercise_science": search_exercise_science
+    "search_exercise_science": search_exercise_science,
 }
+
 
 def list_tools():
     # Convert LangChain tool metadata to Gemini CLI expected format
     definitions = []
     for name, tool in TOOLS.items():
         parameters = {}
-        if hasattr(tool, 'args_schema') and tool.args_schema:
-            if hasattr(tool.args_schema, 'model_json_schema'):
+        if hasattr(tool, "args_schema") and tool.args_schema:
+            if hasattr(tool.args_schema, "model_json_schema"):
                 parameters = tool.args_schema.model_json_schema()
             else:
                 parameters = tool.args_schema.schema()
         else:
             parameters = {"type": "object", "properties": {}}
-            
-        definitions.append({
-            "name": name,
-            "description": tool.description,
-            "parameters": parameters
-        })
+
+        definitions.append({"name": name, "description": tool.description, "parameters": parameters})
     # Print only JSON to stdout
     print(json.dumps(definitions))
+
 
 def call_tool(name):
     try:
@@ -47,7 +45,7 @@ def call_tool(name):
             args = {} if not args_str else json.loads(args_str)
         else:
             args = {}
-        
+
         tool = TOOLS.get(name)
         if tool:
             result = tool.invoke(args)
@@ -61,10 +59,11 @@ def call_tool(name):
         print(json.dumps({"error": str(e)}), file=sys.stderr)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         sys.exit(1)
-        
+
     command = sys.argv[1]
     if command == "list":
         list_tools()

--- a/api/scripts/manage_tools.py
+++ b/api/scripts/manage_tools.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sys
+from typing import Any
 
 # Configure logging to stderr to avoid polluting stdout
 logging.basicConfig(level=logging.ERROR, stream=sys.stderr)
@@ -24,12 +25,13 @@ def list_tools():
     # Convert LangChain tool metadata to Gemini CLI expected format
     definitions = []
     for name, tool in TOOLS.items():
-        parameters = {}
+        parameters: dict[str, Any] = {}
         if hasattr(tool, "args_schema") and tool.args_schema:
-            if hasattr(tool.args_schema, "model_json_schema"):
-                parameters = tool.args_schema.model_json_schema()
-            else:
-                parameters = tool.args_schema.schema()
+            schema_obj = tool.args_schema
+            if hasattr(schema_obj, "model_json_schema"):
+                parameters = schema_obj.model_json_schema()
+            elif hasattr(schema_obj, "schema"):
+                parameters = schema_obj.schema()
         else:
             parameters = {"type": "object", "properties": {}}
 

--- a/api/scripts/manage_tools.py
+++ b/api/scripts/manage_tools.py
@@ -1,0 +1,79 @@
+import sys
+import json
+import os
+import logging
+
+# Configure logging to stderr to avoid polluting stdout
+logging.basicConfig(level=logging.ERROR, stream=sys.stderr)
+
+# Add src to path if needed
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.tools.garmin_uploader import clear_garmin_calendar, upload_workouts_to_garmin
+from src.tools.research_assistant import search_exercise_science
+
+# Mapping of names to LangChain tools
+TOOLS = {
+    "clear_garmin_calendar": clear_garmin_calendar,
+    "upload_workouts_to_garmin": upload_workouts_to_garmin,
+    "search_exercise_science": search_exercise_science
+}
+
+def list_tools():
+    # Convert LangChain tool metadata to Gemini CLI expected format
+    definitions = []
+    for name, tool in TOOLS.items():
+        parameters = {}
+        if hasattr(tool, 'args_schema') and tool.args_schema:
+            if hasattr(tool.args_schema, 'model_json_schema'):
+                parameters = tool.args_schema.model_json_schema()
+            else:
+                parameters = tool.args_schema.schema()
+        else:
+            parameters = {"type": "object", "properties": {}}
+            
+        definitions.append({
+            "name": name,
+            "description": tool.description,
+            "parameters": parameters
+        })
+    # Print only JSON to stdout
+    print(json.dumps(definitions))
+
+def call_tool(name):
+    try:
+        if not sys.stdin.isatty():
+            args_str = sys.stdin.read()
+            if not args_str:
+                args = {}
+            else:
+                args = json.loads(args_str)
+        else:
+            args = {}
+        
+        tool = TOOLS.get(name)
+        if tool:
+            result = tool.invoke(args)
+            if not isinstance(result, (str, dict, list, int, float, bool, type(None))):
+                result = str(result)
+            print(json.dumps(result))
+        else:
+            print(json.dumps({"error": f"Tool '{name}' not found"}), file=sys.stderr)
+            sys.exit(1)
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit(1)
+        
+    command = sys.argv[1]
+    if command == "list":
+        list_tools()
+    elif command == "call":
+        if len(sys.argv) < 3:
+            sys.exit(1)
+        call_tool(sys.argv[2])
+    else:
+        sys.exit(1)

--- a/api/scripts/manage_tools.py
+++ b/api/scripts/manage_tools.py
@@ -1,7 +1,7 @@
-import sys
 import json
-import os
 import logging
+import os
+import sys
 
 # Configure logging to stderr to avoid polluting stdout
 logging.basicConfig(level=logging.ERROR, stream=sys.stderr)
@@ -44,10 +44,7 @@ def call_tool(name):
     try:
         if not sys.stdin.isatty():
             args_str = sys.stdin.read()
-            if not args_str:
-                args = {}
-            else:
-                args = json.loads(args_str)
+            args = {} if not args_str else json.loads(args_str)
         else:
             args = {}
         

--- a/api/src/tools/etl_job.py
+++ b/api/src/tools/etl_job.py
@@ -17,6 +17,11 @@ from garmin_training_toolkit_sdk.extractors import (
 from garmin_training_toolkit_sdk.extractors.biometrics import get_body_composition, get_user_profile
 from garmin_training_toolkit_sdk.utils import find_token_file, get_authenticated_client
 
+from src.utils.config import setup_environment
+
+# Initialize environment
+setup_environment()
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 log = logging.getLogger(__name__)
 

--- a/api/src/tools/retriever.py
+++ b/api/src/tools/retriever.py
@@ -8,6 +8,15 @@ from google.cloud import bigquery
 from src.utils.config import get_config
 
 log = logging.getLogger(__name__)
+
+def _ensure_env():
+    """Ensures environment variables are loaded."""
+    if not os.getenv("GOOGLE_CLOUD_PROJECT"):
+        from src.utils.config import setup_environment
+        setup_environment()
+
+_ensure_env()
+from src.utils.config import get_config
 config = get_config()
 
 # Cache clients per project to reduce initialization overhead

--- a/api/src/tools/retriever.py
+++ b/api/src/tools/retriever.py
@@ -16,7 +16,6 @@ def _ensure_env():
         setup_environment()
 
 _ensure_env()
-from src.utils.config import get_config
 config = get_config()
 
 # Cache clients per project to reduce initialization overhead

--- a/api/src/tools/retriever.py
+++ b/api/src/tools/retriever.py
@@ -9,11 +9,14 @@ from src.utils.config import get_config
 
 log = logging.getLogger(__name__)
 
+
 def _ensure_env():
     """Ensures environment variables are loaded."""
     if not os.getenv("GOOGLE_CLOUD_PROJECT"):
         from src.utils.config import setup_environment
+
         setup_environment()
+
 
 _ensure_env()
 config = get_config()


### PR DESCRIPTION
 Problem
  The @biometric-coach agent was occasionally returning mock data from 2024 instead of the user's live training data. This happened because the retriever.py tool would silently fall back to hardcoded mock
  records if environment variables (like GOOGLE_CLOUD_PROJECT) were not explicitly exported in the shell, even if a valid .env file existed in the project. Additionally, the subagent's retrieval instructions
  were overly complex and prone to environment mismatches.

  Solution
  This PR improves the robustness of the data retrieval layer and simplifies how the AI agent interacts with the platform's biometric data.

   - Automatic Environment Loading: Modified api/src/tools/retriever.py to include an _ensure_env() check. It now proactively calls setup_environment() to load the .env file if critical configuration is
     missing, ensuring the BigQuery client always has the correct project context.
   - Robust Agent Tools: Updated the biometric-coach subagent instructions to use a simplified, tested command for data retrieval. Removed redundant parameter passing in favor of the tool's internal
     configuration logic.
   - Improved Data Integrity: These changes ensure that the "Biometric Context" provided to the LLM is always sourced from the Data Lake when available, preventing confusing "hallucinations" caused by mock data
     fallbacks.

  Validation Results
   - Verified that retriever.py now correctly identifies the bio-intelligence-dev project without manual export commands.
   - Confirmed the agent now successfully pulls the latest activities from April 2026 instead of the October 2024 placeholders.
   - Pushed to branch: fix/etl-sync-and-agent-tools