### PR TITLE
feat(api): implement robust Garmin session refresh and coach troubles…

### DIFF
--- a/.gemini/agents/biometric-coach.md
+++ b/.gemini/agents/biometric-coach.md
@@ -10,6 +10,7 @@ tools:
   - discovered_tool_update_user_zones
   - discovered_tool_sync_biometric_data
   - discovered_tool_analyze_activity_efficiency
+  - discovered_tool_refresh_biometric_session
   - google_web_search
 model: gemini-2.5-flash
 ---
@@ -32,7 +33,14 @@ You are a highly advanced AI Running Coach and Exercise Physiologist. Your goal 
 - **Syncing:** If the user says they just finished a run, use `discovered_tool_sync_biometric_data` before analysis.
 - **Cold Start (New Users):** If no activity history is found, DO NOT prescribe high-intensity workouts. Instead, recommend a 1-2 week **Calibration Phase** (Zone 2 only) and use the Karvonen formula (Age + Resting HR) for initial boundaries.
 
-### 1. Heart Rate Zones (User Profile)
+### 1. Troubleshooting & Reliability (Session Management)
+If you encounter `401 Unauthorized` or `Expired Token` errors when calling biometric tools:
+1. **Immediate Action:** Call `discovered_tool_refresh_biometric_session`.
+2. **Context:** The provider (especially Garmin) requires periodic token refreshes. We have a robust multi-client refresh mechanism (`GARMIN_CONNECT_MOBILE_ANDROID_DI`) to handle this.
+3. **Retry:** After a successful refresh, retry the failed data retrieval or sync operation.
+4. **User Communication:** If refresh fails, inform the user that a manual login may be required.
+
+### 2. Heart Rate Zones (User Profile)
 The user has a unique physiology with a high Aerobic Threshold. Always use these custom zones:
 - **Z1 (Recovery):** < 144 bpm
 - **Z2 (Aerobic Base):** 144 - 165 bpm
@@ -40,7 +48,7 @@ The user has a unique physiology with a high Aerobic Threshold. Always use these
 - **Z4 (Threshold):** 177 - 186 bpm
 - **Z5 (Maximal):** > 186 bpm
 
-### 2. Tool Examples (Standardized Training Plans)
+### 3. Tool Examples (Standardized Training Plans)
 When using `discovered_tool_upload_training_plan`, follow this exact semantic structure:
 
 **Example Workout JSON:**

--- a/api/scripts/manage_tools.py
+++ b/api/scripts/manage_tools.py
@@ -16,6 +16,24 @@ from src.tools.garmin_uploader import clear_calendar, remove_workout, upload_tra
 from src.tools.profile_manager import update_user_zones
 from src.tools.research_assistant import search_exercise_science
 from src.tools.retriever import retrieve_biometric_data
+from src.utils.garmin_auth import refresh_garmin_session
+from garmin_training_toolkit_sdk.utils import find_token_file
+from langchain_core.tools import tool
+
+@tool
+def refresh_biometric_session():
+    """
+    Manually triggers a session refresh for the biometric provider (e.g. Garmin).
+    Use this if you encounter 401 Unauthorized errors or if the user explicitly
+    asks to 'fix the connection' or 'refresh the token'.
+    """
+    token_file = find_token_file()
+    if not token_file:
+        return "Error: Token file not found. Manual authentication required."
+    
+    if refresh_garmin_session(token_file):
+        return "Successfully refreshed biometric session."
+    return "Failed to refresh session. All client IDs exhausted. Manual login may be required."
 
 # Mapping of names to LangChain tools
 TOOLS = {
@@ -27,6 +45,7 @@ TOOLS = {
     "analyze_activity_efficiency": analyze_activity_efficiency,
     "search_exercise_science": search_exercise_science,
     "retrieve_biometric_data": retrieve_biometric_data,
+    "refresh_biometric_session": refresh_biometric_session,
 }
 
 

--- a/api/src/tools/etl_job.py
+++ b/api/src/tools/etl_job.py
@@ -16,9 +16,10 @@ from garmin_training_toolkit_sdk.extractors import (
     get_training_status,
 )
 from garmin_training_toolkit_sdk.extractors.biometrics import get_body_composition, get_user_profile
-from garmin_training_toolkit_sdk.utils import find_token_file, get_authenticated_client
+from garmin_training_toolkit_sdk.utils import find_token_file
 
 from src.utils.config import setup_environment
+from src.utils.garmin_auth import get_robust_client
 
 # Initialize environment
 setup_environment()
@@ -159,7 +160,7 @@ def run_etl():
         log.error("Garmin authentication token not found.")
         return
 
-    client = get_authenticated_client(token_file)
+    client = get_robust_client(token_file)
     end_date = datetime.now()
 
     # --- 1. Incremental Activities ---

--- a/api/src/utils/garmin_auth.py
+++ b/api/src/utils/garmin_auth.py
@@ -1,0 +1,73 @@
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+from garminconnect import Garmin
+from garmin_training_toolkit_sdk.utils import find_token_file, save_tokens
+
+log = logging.getLogger(__name__)
+
+DI_CLIENT_IDS = (
+    "GARMIN_CONNECT_MOBILE_ANDROID_DI_2025Q2",
+    "GARMIN_CONNECT_MOBILE_ANDROID_DI_2024Q4",
+    "GARMIN_CONNECT_MOBILE_ANDROID_DI",
+    "GARMIN_CONNECT_MOBILE_IOS_DI",
+)
+
+def refresh_garmin_session(token_file: Path) -> bool:
+    """
+    Attempts to refresh the Garmin session using multiple known client IDs.
+    Updates the token file on success.
+    """
+    if not token_file.exists():
+        log.error(f"Token file not found at {token_file}")
+        return False
+
+    with open(token_file) as f:
+        tokens = json.load(f)
+
+    for client_id in DI_CLIENT_IDS:
+        log.info(f"Attempting session refresh with client ID: {client_id}")
+        client = Garmin()
+        try:
+            client.client.loads(json.dumps(tokens))
+            client.client.di_client_id = client_id
+            client.client._refresh_di_token()
+            
+            new_tokens = json.loads(client.client.dumps())
+            save_tokens(new_tokens)
+            log.info(f"Successfully refreshed Garmin session using {client_id}")
+            return True
+        except Exception as e:
+            log.debug(f"Refresh failed with {client_id}: {e}")
+    
+    log.error("Failed to refresh Garmin session with all known client IDs.")
+    return False
+
+def get_robust_client(token_file: Optional[Path] = None):
+    """
+    Returns an authenticated Garmin client, automatically attempting a refresh
+    if the initial authentication fails or if the token is expired.
+    """
+    from garmin_training_toolkit_sdk.utils import get_authenticated_client
+    
+    if token_file is None:
+        token_file = find_token_file()
+    
+    if not token_file:
+        raise Exception("Garmin tokens not found. Please authenticate first.")
+
+    try:
+        # Try initial authentication
+        client = get_authenticated_client(token_file)
+        # Test the connection with a lightweight call
+        client.get_userprofile_settings()
+        return client
+    except Exception as e:
+        error_str = str(e).lower()
+        if "401" in error_str or "unauthorized" in error_str or "expired" in error_str:
+            log.info("Authentication failed (401/Expired). Attempting proactive refresh...")
+            if refresh_garmin_session(token_file):
+                return get_authenticated_client(token_file)
+        raise

--- a/manage_tools.sh
+++ b/manage_tools.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-/home/federico/.local/bin/uv run --project api python api/scripts/manage_tools.py "$@"
+/home/fsirio/.local/bin/uv run --project api python api/scripts/manage_tools.py "$@"


### PR DESCRIPTION
…hooting

- Added garmin_auth.py utility with multi-client refresh logic (GARMIN_CONNECT_MOBILE_ANDROID_DI fallback).
- Updated ETL job to use self-healing get_robust_client.
- Added refresh_biometric_session tool to manage_tools.py.
- Updated biometric-coach agent with session management instructions.
- Fixed uv path in manage_tools.sh.