### PR TITLE
feat: auto-calibration of Max HR profile & Karvonen zone recalculation

### DIFF
--- a/api/scripts/manage_tools.py
+++ b/api/scripts/manage_tools.py
@@ -9,6 +9,7 @@ from src.tools.alerting import check_proactive_alerts
 from src.tools.historical_biometrics import compare_shoe_biomechanics
 from src.tools.nutrition_modeler import assess_glycogen_readiness
 from src.tools.predictive_modeler import calculate_critical_power_and_w_prime
+from src.tools.profile_manager import calibrate_profile_max_hr
 
 # Configure logging to stderr to avoid polluting stdout
 logging.basicConfig(level=logging.ERROR, stream=sys.stderr)
@@ -73,6 +74,7 @@ TOOLS = {
     "assess_glycogen_readiness": assess_glycogen_readiness,
     "calculate_critical_power_and_w_prime": calculate_critical_power_and_w_prime,
     "compare_shoe_biomechanics": compare_shoe_biomechanics,
+    "calibrate_profile_max_hr": calibrate_profile_max_hr,
     "generate_deep_historical_report": generate_deep_historical_report,
     "execute_exploratory_query": execute_exploratory_query,
     "execute_exploratory_query_dry_run": execute_exploratory_query_dry_run,

--- a/api/src/agent/graph.py
+++ b/api/src/agent/graph.py
@@ -2,6 +2,7 @@ from src.tools.alerting import check_proactive_alerts
 from src.tools.historical_biometrics import compare_shoe_biomechanics
 from src.tools.nutrition_modeler import assess_glycogen_readiness
 from src.tools.predictive_modeler import calculate_critical_power_and_w_prime
+from src.tools.profile_manager import calibrate_profile_max_hr
 
 """LangGraph definition for the Biometric AI Coach agent."""
 
@@ -509,6 +510,7 @@ def node_analyze(state: AgentState) -> dict[str, Any]:
             assess_glycogen_readiness,
             calculate_critical_power_and_w_prime,
             compare_shoe_biomechanics,
+            calibrate_profile_max_hr,
             generate_deep_historical_report,
             execute_exploratory_query,
             execute_exploratory_query_dry_run,
@@ -706,6 +708,7 @@ def tool_node(state: AgentState) -> Any:
             assess_glycogen_readiness,
             calculate_critical_power_and_w_prime,
             compare_shoe_biomechanics,
+            calibrate_profile_max_hr,
             generate_deep_historical_report,
             execute_exploratory_query,
             execute_exploratory_query_dry_run,

--- a/api/src/tools/profile_manager.py
+++ b/api/src/tools/profile_manager.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import date, datetime
 from typing import Literal
@@ -390,3 +391,82 @@ def save_calibration_marker(
     except Exception as e:
         log.error(f"❌ BigQuery calibration marker save failed: {e}")
         return f"Saved marker in Firestore, but BigQuery sync failed: {e}"
+
+
+class MaxHRCalibrationInput(BaseModel):
+    """Input schema for auto-calibrating user max_hr from peak activity telemetry."""
+
+    user_id: str = Field(..., description="The internal user ID (mandatory).")
+    observed_peak_hr: float = Field(..., description="Observed peak heart rate in bpm from FIT telemetry.")
+    activity_name: str | None = Field(None, description="Name or type of activity (e.g. 'Tigre 10k Race').")
+
+
+@tool(args_schema=MaxHRCalibrationInput)
+def calibrate_profile_max_hr(
+    user_id: str,
+    observed_peak_hr: float,
+    activity_name: str | None = None,
+) -> str:
+    """
+    Evaluates observed peak heart rate from FIT activity telemetry against the stored Max HR in the personal profile.
+    If observed_peak_hr > stored max_hr (e.g., observed 179 bpm vs stored 123 bpm), automatically updates max_hr,
+    recalculates Karvonen HR zones, and saves the new threshold to Firestore and BigQuery.
+    """
+    try:
+        profile = get_user_profile(user_id)
+        current_pcp = profile.get("personal_calibration_profile", {})
+        stored_raw = current_pcp.get("max_hr", 185.0)
+        stored_max_hr = float(stored_raw.get("value", 185.0)) if isinstance(stored_raw, dict) else float(stored_raw)
+
+        if observed_peak_hr > stored_max_hr:
+            # Auto-calibration triggered
+            context_str = f"Auto-calibrated from peak HR of {observed_peak_hr} bpm during {activity_name or 'activity'}"
+            save_calibration_marker.invoke(
+                {
+                    "marker_type": "max_hr",
+                    "marker_value": observed_peak_hr,
+                    "context": context_str,
+                    "user_id": user_id,
+                }
+            )
+
+            # Recalculate Karvonen Z1-Z5 Zones (Assuming Resting HR ~ 55 bpm)
+            rhr_raw = current_pcp.get("resting_hr", 55.0)
+            rhr = float(rhr_raw.get("value", 55.0)) if isinstance(rhr_raw, dict) else float(rhr_raw)
+            hrr = observed_peak_hr - rhr
+            z1 = round(rhr + 0.50 * hrr, 1)
+            z2 = round(rhr + 0.60 * hrr, 1)
+            z3 = round(rhr + 0.70 * hrr, 1)
+            z4 = round(rhr + 0.80 * hrr, 1)
+            z5 = round(rhr + 0.90 * hrr, 1)
+
+            res = {
+                "user_id": user_id,
+                "action": "MAX_HR_AUTOCALIBRATED",
+                "previous_max_hr": stored_max_hr,
+                "new_max_hr": observed_peak_hr,
+                "observed_peak_hr": observed_peak_hr,
+                "activity": activity_name,
+                "recalculated_karvonen_zones": {
+                    "Z1_recovery": f"{z1}-{z2} bpm",
+                    "Z2_aerobic_base": f"{z2}-{z3} bpm",
+                    "Z3_tempo": f"{z3}-{z4} bpm",
+                    "Z4_threshold": f"{z4}-{z5} bpm",
+                    "Z5_anaerobic_peak": f">{z5} bpm",
+                },
+                "status": f"Max HR updated from {stored_max_hr} to {observed_peak_hr} bpm. Karvonen HR zones recalculated.",
+            }
+            return json.dumps(res, indent=2)
+        return json.dumps(
+            {
+                "user_id": user_id,
+                "action": "NO_CHANGE_NEEDED",
+                "stored_max_hr": stored_max_hr,
+                "observed_peak_hr": observed_peak_hr,
+                "status": f"Observed peak HR ({observed_peak_hr} bpm) is within current stored Max HR ({stored_max_hr} bpm).",
+            },
+            indent=2,
+        )
+    except Exception as e:
+        log.error(f"❌ Failed calibrating profile Max HR: {e}")
+        return json.dumps({"error": str(e)})

--- a/api/tests/test_profile_calibration.py
+++ b/api/tests/test_profile_calibration.py
@@ -1,0 +1,54 @@
+import json
+from unittest.mock import patch
+
+from src.tools.profile_manager import calibrate_profile_max_hr
+
+
+@patch("src.tools.profile_manager.save_calibration_marker")
+@patch("src.tools.profile_manager.get_user_profile")
+def test_calibrate_profile_max_hr_triggered(mock_get_profile, mock_save_marker):
+    """Test max_hr auto-calibration when peak HR exceeds stored threshold."""
+    mock_get_profile.return_value = {
+        "personal_calibration_profile": {
+            "max_hr": {"value": 123.0},
+            "resting_hr": {"value": 55.0},
+        }
+    }
+    mock_save_marker.invoke.return_value = "Successfully saved marker"
+
+    raw_res = calibrate_profile_max_hr.invoke(
+        {
+            "user_id": "mercedes",
+            "observed_peak_hr": 179.0,
+            "activity_name": "Tigre 10k Race",
+        }
+    )
+
+    res = json.loads(raw_res)
+    assert res["user_id"] == "mercedes"
+    assert res["action"] == "MAX_HR_AUTOCALIBRATED"
+    assert res["previous_max_hr"] == 123.0
+    assert res["new_max_hr"] == 179.0
+    assert "recalculated_karvonen_zones" in res
+    mock_save_marker.invoke.assert_called_once()
+
+
+@patch("src.tools.profile_manager.get_user_profile")
+def test_calibrate_profile_max_hr_no_change(mock_get_profile):
+    """Test max_hr when observed HR is within stored limit."""
+    mock_get_profile.return_value = {
+        "personal_calibration_profile": {
+            "max_hr": {"value": 185.0},
+        }
+    }
+
+    raw_res = calibrate_profile_max_hr.invoke(
+        {
+            "user_id": "fsirio",
+            "observed_peak_hr": 165.0,
+        }
+    )
+
+    res = json.loads(raw_res)
+    assert res["user_id"] == "fsirio"
+    assert res["action"] == "NO_CHANGE_NEEDED"


### PR DESCRIPTION
Implements calibrate_profile_max_hr tool to automatically detect when real activity telemetry peak HR exceeds profile Max HR (e.g. 179 bpm vs 123 bpm default), update Firestore/BigQuery profiles, and recalculate Karvonen Z1-Z5 HR zones.